### PR TITLE
EKSの基本的なクラスター構築用terraformを整備する

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.19.0"
+  constraints = "5.19.0"
+  hashes = [
+    "h1:MJclj56jijp7T4V4g5tzHXS3M8vUdJAcBRjEstBh0Hc=",
+    "zh:03aa0f857c6dfce5f46c9bf3aad45534b9421e68983994b6f9dd9812beaece9c",
+    "zh:0639818c5bf9f9943667f39ec38bb945c9786983025dff407390133fa1ca5041",
+    "zh:0b82ad42ced8fb4a138eaf2fd37cf6059ca0bb482114b35fb84f22fc1500324a",
+    "zh:173e8c19a9f1d8f6457c80f4a73a92f420a81d650fc4ad0f97a5dc4b9485bba8",
+    "zh:42913a40ddfe9b4f3c78ad2e3cdc1dcfd48151bc132dc6b49fc32cd6da79db21",
+    "zh:452db5caca2e53d5f7090979d518e77aa5fd98385514b11ee2ce76a46e89cb53",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a12377ade89ee18d9be116436e411e8396898bd70b21ab027c161c785e86238d",
+    "zh:aa9e4746ba49044ad5b4dda57fcdba7bc16fe65f696766fb2c55c30a27abf844",
+    "zh:adfaee76d283f1c321fad2e4154be88d57da8c2ecfdca9516c8920bd2ece36ed",
+    "zh:bf6fbc6d60661c03ed2214173c1deced908dc62480dd41e67ac399fa4abd7467",
+    "zh:cb685da03ad00d1a27891f3d366d75e8795ac81f1b427888b434e6832ca40633",
+    "zh:e0432c78dfaf2baebe2bf5c0ad8087f547c69c2c5a00e4c1dcd5a6344ce726df",
+    "zh:e0ec9ccb8d34d6d0d8bf7f8628c223951832b4d50ea8887fc711fa854b3a28b4",
+    "zh:f274397ada4ef3c1dce2f70e719c8ccf19fc4e7a2e3f45d018764c6267fd7157",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/http" {
+  version = "3.4.3"
+  hashes = [
+    "h1:Ep4kCumou6eEyPkFJFAfuzd7IAsYM7xMAdDaFTwdDZ8=",
+    "zh:001e12b8079955a9fa7f8fcd515ae665b2e1087107fd337c4b872e88a86d540b",
+    "zh:0874fb3f870b2ac24c967a9685f2da641079589024109340389694696301a85b",
+    "zh:3b5e533c3d2859575945568aad0aac66b71bfc709706231fc2de94e01ca76d7f",
+    "zh:622ee28d42ed9d4b1399dde377db515e62cac08bd65bb2455068621f7a42d90d",
+    "zh:6dea688d78840a3f678e06ee602d37c766ce2ee625dcdce0c6658116ebcbde8e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7f57a1436a464bc2e1698457b402ff0fd98ef9e7dcf6707d6bd0debc67fad164",
+    "zh:829d89d82e6fc3c89714950dc8afa51d622bb8e4f4bd5c73037505fb55a67834",
+    "zh:e453202d09b62531ed3278926307d315276e05784e7c6448a2c21c6a2da6e48f",
+    "zh:e76edc035240b4ad9334b4a0282b44a086e001df3007a2fc51f6262c4db032d1",
+    "zh:eeb0379da9093e155a193f666079de6baf8ed02855bf2a443448903f7cfef378",
+    "zh:fcb00eeb665ccae383645173d8e10c3071946396629a7797db39c798997f21b0",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # stamp-iot-eks
+
+#### 前提
+* 以下を作業PCにインストールしていること
+  * aws
+  * terraform
+* 適切なIAMロールを持ったAWSアカウントで `aws configure` を実行済みであること
+
+#### 手順
+* `terraform plan`
+* `terraform apply`
+* `aws eks update-kubeconfig --name <クラスター名>--region <リージョン>`
+  * kubeconfig が更新される
+* `kubectl get pods -A` などを実行できることを確認する

--- a/database.tf
+++ b/database.tf
@@ -1,0 +1,128 @@
+#
+# RDS
+#
+resource "aws_db_instance" "rds" {
+  db_name              = var.rds_db_name
+  engine               = "postgres"
+  engine_version       = "16.3"
+  instance_class       = "db.t3.micro"
+  storage_type         = "gp2"
+  port = 5432
+  username             = var.rds_user_name
+  password             = var.rds_password
+  parameter_group_name = aws_db_parameter_group.rds-pg.name
+  skip_final_snapshot  = true
+  iam_database_authentication_enabled = true
+  multi_az = false
+  publicly_accessible = false
+  storage_encrypted = true
+  kms_key_id = aws_kms_key.rds_storage.arn
+  vpc_security_group_ids = [
+    aws_security_group.rds-sg.id
+  ]
+  db_subnet_group_name = aws_db_subnet_group.rds-sng.name
+
+  # 割り当てストレージサイズ(GB)
+  allocated_storage    = 10
+  # メジャーバージョンの更新許可
+  allow_major_version_upgrade = false
+  # マイナーバージョンの自動更新
+  auto_minor_version_upgrade = true
+}
+
+resource "aws_db_parameter_group" "rds-pg" {
+  name   = "rds-pg"
+  family = "postgres16"
+}
+
+resource "aws_db_subnet_group" "rds-sng" {
+  name = "db"
+  subnet_ids = [
+    for value in aws_subnet.sn : value.id
+  ]
+}
+
+resource "aws_kms_key" "rds_storage" {
+  key_usage               = "ENCRYPT_DECRYPT"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+
+resource "aws_security_group" "rds-sg" {
+  name = "rds-sg"
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "rds"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "rds-ingress-sgr" {
+  from_port                = 5432
+  to_port                  = 5432
+  ip_protocol                 = "tcp"
+  security_group_id        = aws_security_group.rds-sg.id
+  cidr_ipv4                = var.vpc_cidr_block
+}
+
+resource "aws_vpc_security_group_egress_rule" "rds-egress-sgr" {
+  ip_protocol              = "-1"
+  cidr_ipv4                = "0.0.0.0/0"
+  security_group_id        = aws_security_group.rds-sg.id
+}
+
+#
+# Redis
+#
+resource "aws_security_group" "redis-sg" {
+  name = "redis-sg"
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "redis"
+  }
+}
+
+resource "aws_security_group_rule" "redis-sgr" {
+  type                     = "ingress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.kubectl_sg.id
+  security_group_id        = aws_security_group.redis-sg.id
+}
+
+resource "aws_elasticache_replication_group" "redis" {
+  replication_group_id          = var.redis_cluster_id
+  node_type                     = "cache.t2.micro"
+  engine_version                = "7.1"
+  port                          = 6379
+  subnet_group_name             = aws_elasticache_subnet_group.redis-subg.name
+  parameter_group_name          = aws_elasticache_parameter_group.redis-pg.name
+  automatic_failover_enabled    = true
+  num_node_groups         = 1
+  replicas_per_node_group = 1
+
+  description = "Redis Replicaiton Group"
+  
+  security_group_ids = [
+    aws_security_group.redis-sg.id
+  ]
+}
+
+resource "aws_elasticache_parameter_group" "redis-pg" {
+  name   = "redis-cluster-pg"
+  family = "redis7"
+
+  parameter {
+    name  = "cluster-enabled"
+    value = "yes"
+  }
+}
+
+resource "aws_elasticache_subnet_group" "redis-subg" {
+  name       = "redis-subnet"
+  subnet_ids = [
+    for value in aws_subnet.sn : value.id
+  ]
+}

--- a/ecr.tf
+++ b/ecr.tf
@@ -1,0 +1,57 @@
+#
+# ECR
+#
+resource "aws_ecr_repository" "ems-frontend" {
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = "true"
+  }
+
+  image_tag_mutability = "MUTABLE"
+  name                 = "ems-frontend"
+}
+
+resource "aws_ecr_lifecycle_policy" "ems-frontend" {
+  repository = aws_ecr_repository.ems-frontend.name
+  policy     = jsonencode(local.ecr-lifecycle-policy)
+}
+
+resource "aws_ecr_repository" "ems-backend" {
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = "true"
+  }
+
+  image_tag_mutability = "MUTABLE"
+  name                 = "ems-backend"
+}
+
+resource "aws_ecr_lifecycle_policy" "ems-backend" {
+  repository = aws_ecr_repository.ems-backend.name
+  policy     = jsonencode(local.ecr-lifecycle-policy)
+}
+
+locals {
+  ecr-lifecycle-policy = {
+    rules = [
+      {
+        action = {
+          type = "expire"
+        }
+        description  = "最新のイメージを5つだけ残す"
+        rulePriority = 1
+        selection = {
+          countNumber = 5
+          countType   = "imageCountMoreThan"
+          tagStatus   = "any"
+        }
+      },
+    ]
+  }
+}

--- a/eks.tf
+++ b/eks.tf
@@ -1,0 +1,62 @@
+#
+# Cluster
+#
+resource "aws_eks_cluster" "cluster" {
+  name     = var.cluster_name
+  role_arn = aws_iam_role.eks-master.arn
+  version  = var.cluster_version
+
+  vpc_config {
+    security_group_ids      = ["${aws_security_group.cluster-sg.id}"]
+    subnet_ids              = aws_subnet.sn.*.id
+    endpoint_private_access = true
+    endpoint_public_access  = true
+  }
+}
+
+data "aws_ssm_parameter" "eks_ami_release_version" {
+  name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.cluster.version}/amazon-linux-2/recommended/release_version"
+}
+
+resource "aws_eks_node_group" "node_group" {
+  cluster_name    = aws_eks_cluster.cluster.name
+  node_group_name = var.node_group_name
+  version         = var.cluster_version
+  release_version = nonsensitive(data.aws_ssm_parameter.eks_ami_release_version.value)
+  node_role_arn   = aws_iam_role.eks-node.arn
+  instance_types  = var.node_instance_types
+  subnet_ids      = aws_subnet.sn[*].id
+
+  scaling_config {
+    desired_size = var.node_desired_size
+    max_size     = var.node_max_size
+    min_size     = var.node_min_size
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks-cluster,
+    aws_iam_role_policy_attachment.eks-service,
+    aws_iam_role_policy_attachment.eks-worker-node,
+    aws_iam_role_policy_attachment.eks-cni,
+    aws_iam_role_policy_attachment.ecr-ro,
+  ]
+}
+
+resource "aws_security_group" "cluster-sg" {
+  name   = "eks-cluster-sg"
+  vpc_id = aws_vpc.vpc.id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr_block]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr_block]
+  }
+}

--- a/endpoint.tf
+++ b/endpoint.tf
@@ -1,0 +1,105 @@
+resource "aws_ec2_instance_connect_endpoint" "eice" {
+  subnet_id          = aws_subnet.kubectl_subnet.id
+  security_group_ids = [aws_security_group.kubectl_sg.id]
+}
+
+data "aws_ssm_parameter" "ami" {
+  name = "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
+}
+
+resource "aws_network_interface" "kubectl_ni" {
+  subnet_id       = aws_subnet.kubectl_subnet.id
+  security_groups = [aws_security_group.kubectl_sg.id]
+}
+
+resource "aws_iam_instance_profile" "kubectl_iam_instance_profile" {
+  name = var.instance_iam_instance_profile_name
+  role = aws_iam_role.kubectl_role.name
+}
+
+resource "aws_instance" "kubectl_instance" {
+  ami                  = data.aws_ssm_parameter.ami.value
+  instance_type        = var.instance_type
+  iam_instance_profile = aws_iam_instance_profile.kubectl_iam_instance_profile.name
+  network_interface {
+    network_interface_id = aws_network_interface.kubectl_ni.id
+    device_index         = 0
+  }
+}
+
+resource "aws_iam_policy" "kubectl_policy" {
+  name        = "test_kubectl_policy"
+  description = "test kubectl policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "sts:GetCallerIdentity",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role" "kubectl_role" {
+  name = "test_kubectl_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "kubectl_iam_role_policy_attachment" {
+  policy_arn = aws_iam_policy.kubectl_policy.arn
+  role       = aws_iam_role.kubectl_role.name
+}
+
+data "http" "client_global_ip" {
+  url = "https://ifconfig.co/ip"
+}
+
+locals {
+  allowed_cidr = replace("${data.http.client_global_ip.response_body}/32", "\n", "")
+}
+
+resource "aws_subnet" "kubectl_subnet" {
+  vpc_id                  = aws_vpc.vpc.id
+  map_public_ip_on_launch = true
+  cidr_block              = var.instance_subnet_cidr_block
+}
+
+resource "aws_route_table_association" "kubectl_rta" {
+  subnet_id      = aws_subnet.kubectl_subnet.id
+  route_table_id = aws_route_table.rt.id
+}
+
+resource "aws_security_group" "kubectl_sg" {
+  name = "kubectl-sg"
+  vpc_id = aws_vpc.vpc.id
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [local.allowed_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,64 @@
+#
+# IAM
+#
+resource "aws_iam_role" "eks-master" {
+  name = "cluster-service-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        Service = "eks.amazonaws.com"
+      },
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eks-cluster" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.eks-master.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks-service" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = aws_iam_role.eks-master.name
+}
+
+resource "aws_iam_role" "eks-node" {
+  name = "eks-node-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eks-worker-node" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.eks-node.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks-cni" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.eks-node.name
+}
+
+resource "aws_iam_role_policy_attachment" "ecr-ro" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.eks-node.name
+}
+
+resource "aws_iam_instance_profile" "eks-node" {
+  name = "eks-node-profile"
+  role = aws_iam_role.eks-node.name
+}

--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,40 @@
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "zone-type"
+    values = ["availability-zone"]
+  }
+}
+
+resource "aws_vpc" "vpc" {
+  cidr_block = var.vpc_cidr_block
+
+  tags = {
+    Name = var.vpc_name
+  }
+}
+
+resource "aws_subnet" "sn" {
+  count                   = var.num_subnets
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = cidrsubnet(var.vpc_cidr_block, 8, count.index)
+  availability_zone       = element(data.aws_availability_zones.available.names, count.index % var.num_subnets)
+  map_public_ip_on_launch = true
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.vpc.id
+}
+
+resource "aws_route_table" "rt" {
+  vpc_id = aws_vpc.vpc.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+}
+
+resource "aws_route_table_association" "rta" {
+  count          = var.num_subnets
+  subnet_id      = element(aws_subnet.sn.*.id, count.index)
+  route_table_id = aws_route_table.rt.id
+}

--- a/route53.tf
+++ b/route53.tf
@@ -1,0 +1,57 @@
+#
+# Route53
+#
+resource "aws_route53_zone" "host_domain" {
+  name = var.host_domain
+}
+
+resource "aws_route53_zone" "app_subdomain" {
+  name = var.app_domain_name
+}
+
+resource "aws_route53_record" "route53_acm_dns_resolve" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name = each.value.name
+  records = [each.value.record]
+  type = each.value.type
+  ttl = "300"
+
+  zone_id = aws_route53_zone.host_domain.id
+}
+
+resource "aws_route53_record" "ns_record_for_app_subdomain" {
+  name    = aws_route53_zone.app_subdomain.name
+  type    = "NS"
+  zone_id = aws_route53_zone.host_domain.id
+  records = [
+    aws_route53_zone.app_subdomain.name_servers[0],
+    aws_route53_zone.app_subdomain.name_servers[1],
+    aws_route53_zone.app_subdomain.name_servers[2],
+    aws_route53_zone.app_subdomain.name_servers[3],
+  ]
+  ttl = 172800
+}
+
+#
+# 証明書
+#
+resource "aws_acm_certificate" "cert" {
+  domain_name               = "*.${var.host_domain}"
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "acm"
+  }
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "registry.terraform.io/hashicorp/aws"
+      version = "5.19.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.provider_region
+
+  default_tags {
+    tags = var.aws_tags
+  }
+
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,131 @@
+#
+# AWS
+#
+
+variable "aws_tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "vpc_cidr_block" {
+  type    = string
+}
+
+variable "num_subnets" {
+  type    = number
+  default = "2"
+}
+
+variable "provider_region" {
+  type    = string
+  default = "ap-northeast-1"
+}
+
+variable "aws_access_key" {
+  type    = string
+}
+
+variable "aws_secret_key" {
+  type    = string
+}
+
+variable "vpc_name" {
+  type    = string
+}
+
+#
+# EKS
+#
+
+variable "cluster_name" {
+  type    = string
+}
+
+variable "cluster_version" {
+  type    = string
+  default = "1.30"
+}
+
+variable "node_group_name" {
+  type    = string
+}
+
+variable "node_instance_types" {
+  type    = list(string)
+  default = ["t3.micro"]
+}
+
+variable "node_desired_size" {
+  type    = number
+}
+
+variable "node_max_size" {
+  type    = number
+}
+
+variable "node_min_size" {
+  type    = number
+}
+
+#
+# kubectl instance
+#
+
+variable "instance_iam_instance_profile_name" {
+  type    = string
+  default = "kubectl_instance_iam_instance_profile"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.micro"
+}
+
+variable "instance_subnet_cidr_block" {
+  type    = string
+  default = "10.0.10.0/24"
+}
+
+variable "instance_kubectl_install_url" {
+  type    = string
+  default = "https://s3.us-west-2.amazonaws.com/amazon-eks/1.27.6/2023-10-17/bin/linux/amd64/kubectl"
+}
+
+variable "instance_kubectl_sha_install_url" {
+  type    = string
+  default = "https://s3.us-west-2.amazonaws.com/amazon-eks/1.27.6/2023-10-17/bin/linux/amd64/kubectl.sha256"
+}
+
+#
+# RDS
+#
+
+variable "rds_db_name" {
+  type    = string
+}
+variable "rds_user_name" {
+  type    = string
+}
+variable "rds_password" {
+  type    = string
+}
+
+#
+# Redis
+#
+
+variable "redis_cluster_id" {
+  type     = string
+}
+
+#
+# Route53
+#
+
+variable "host_domain" {
+  type     = string
+}
+
+variable "app_domain_name" {
+  type     = string
+}


### PR DESCRIPTION
## 実装内容

- 基本的なEKSを構築できるterraformを作成
  - manifestについては https://github.com/mktkhr/stamp-iot 側のリポジトリに追加予定

## 確認手順

- 前提として，適切なIAMポリシーが適用されているAWSアカウントで `aws configure` されていること 
- `terraform apply`

## スクリーンショット

- 特になし

resolve #1