### PR TITLE
Elasticacheをt2からt3に変更する

### DIFF
--- a/database.tf
+++ b/database.tf
@@ -94,7 +94,7 @@ resource "aws_security_group_rule" "redis-sgr" {
 
 resource "aws_elasticache_replication_group" "redis" {
   replication_group_id          = var.redis_cluster_id
-  node_type                     = "cache.t2.micro"
+  node_type                     = "cache.t3.micro"
   engine_version                = "7.1"
   port                          = 6379
   subnet_group_name             = aws_elasticache_subnet_group.redis-subg.name
@@ -102,6 +102,7 @@ resource "aws_elasticache_replication_group" "redis" {
   automatic_failover_enabled    = true
   num_node_groups         = 1
   replicas_per_node_group = 1
+  multi_az_enabled        = false
 
   description = "Redis Replicaiton Group"
   


### PR DESCRIPTION
## 実装内容

- Elasticacheをt2からt3に移行
  - コスト的に無効化しているマルチAZを明記するようにした

## 確認手順

- WEBコンソールで更新を確認

## スクリーンショット

- t3に変わり，マルチAZを設定できること

<img width="538" alt="スクリーンショット 2024-06-30 18 16 22" src="https://github.com/mktkhr/stamp-iot-eks/assets/51685340/5676af69-0670-46e7-9f69-657c6c8e6eb9">


resolve #10 
